### PR TITLE
Changed line endings for new scripts to match Windows

### DIFF
--- a/ProjectSettings/EditorSettings.asset
+++ b/ProjectSettings/EditorSettings.asset
@@ -5,7 +5,7 @@ EditorSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 13
   m_SerializationMode: 2
-  m_LineEndingsForNewScripts: 0
+  m_LineEndingsForNewScripts: 2
   m_DefaultBehaviorMode: 0
   m_PrefabRegularEnvironment: {fileID: 0}
   m_PrefabUIEnvironment: {fileID: 0}


### PR DESCRIPTION
### Pull Request Description

**Title:** Changed line endings for new scripts in Unity to match Windows

**Description:**
This pull request addresses the line ending format for newly added scripts in the project. The changes ensure that all new scripts created in Unity utilize Windows-style line endings (CRLF) to maintain compatibility with all environments. 

**Commits:**
- Changed line endings for new scripts in Unity to match Windows

This update helps keep the project easy to develop on multiple OS's, as it prevents potential issues related to line ending discrepancies when pushing/pulling scripts. Please review the changes and let me know if there are any concerns.